### PR TITLE
Add support for <select>'s without an existing id attribute

### DIFF
--- a/foundation-select.js
+++ b/foundation-select.js
@@ -13,6 +13,15 @@
         select = $(this);
         if(typeof select.attr('id') == 'undefined') {
           selectId = 'foundation-select-'+select.attr('name').replace('[','').replace(']','');
+          if($('#'+selectId).length) {
+            i = 1;
+            newSelectId = selectId+'-'+i;
+            while($('#'+newSelectId).length) {
+              i++;
+              newSelectId = selectId+'-'+i;
+            }
+            selectId = newSelectId;
+          }
           select.attr('id', selectId);
         } else {
           selectId = select.attr('id');

--- a/foundation-select.js
+++ b/foundation-select.js
@@ -11,7 +11,12 @@
         selected = '';
         translateClasses = '';
         select = $(this);
-        selectId = select.attr('id');
+        if(typeof select.attr('id') == 'undefined') {
+          selectId = 'foundation-select-'+select.attr('name').replace('[','').replace(']','');
+          select.attr('id', selectId);
+        } else {
+          selectId = select.attr('id');
+        }
         multiple = false;
         multiple = select.prop('multiple') ? true : false;
         options = '';


### PR DESCRIPTION
Allow users to use the plugin without adding id´s to their select-tags